### PR TITLE
Move <slimlog_export.h> include to common.h

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@
 *   **Thread Safety:** Configurable threading policy (`SingleThreadedPolicy` or `MultiThreadedPolicy`).
 *   **Minimalistic:** Clean, modern C++20 codebase. Can be used as a header-only library or built as a static/shared library.
 
+## Minimum Supported Compiler Versions
+
+| Compiler | std/fmt           | fmt only          |
+|----------|-------------------|-------------------|
+| **MSVC** | 19.29 (VS 16.11)  | 19.29 (VS 16.10)  |
+| **GCC**  | 13.1              | 11.1              |
+| **Clang**| 17.0.0            | 14.0.0            |
+| **ICX**  | 2024.0.0          | 2022.2.0          |
+
+> **Note:** "std/fmt" means that it's possible to build both using `<fmt/format.h>` and `<format>` from standard C++ library, while "fmt only" means that standard C++ library lacks necessary features for `<format>` compatibility.
+
 ## Installation
 
 ### CMake

--- a/include/slimlog/common.h
+++ b/include/slimlog/common.h
@@ -11,6 +11,13 @@
 #include <cstddef>
 #include <cstdint>
 
+#ifndef SLIMLOG_HEADER_ONLY
+#include "slimlog_export.h" // IWYU pragma: export
+#else
+#define SLIMLOG_EXPORT
+#define SLIMLOG_NO_EXPORT
+#endif
+
 namespace slimlog {
 
 /**

--- a/include/slimlog/format.h
+++ b/include/slimlog/format.h
@@ -5,10 +5,9 @@
 
 #pragma once
 
+#include "slimlog/common.h"
 #include "slimlog/location.h"
 #include "slimlog/util/buffer.h"
-
-#include <slimlog_export.h>
 
 #ifdef SLIMLOG_FMTLIB
 #if __has_include(<fmt/base.h>)

--- a/include/slimlog/logger-inl.h
+++ b/include/slimlog/logger-inl.h
@@ -112,7 +112,7 @@ auto Logger<Char, ThreadingPolicy, BufferSize, Allocator>::add_sink(
 {
     bool added = false;
     {
-        const typename ThreadingPolicy::UniqueLock lock(m_mutex);
+        const typename ThreadingPolicy::template UniqueLock<decltype(m_mutex)> lock(m_mutex);
         added = m_sinks.insert_or_assign(sink, true).second;
     }
     if (added) {
@@ -128,7 +128,7 @@ auto Logger<Char, ThreadingPolicy, BufferSize, Allocator>::remove_sink(
 
     bool erased = false;
     {
-        const typename ThreadingPolicy::UniqueLock lock(m_mutex);
+        const typename ThreadingPolicy::template UniqueLock<decltype(m_mutex)> lock(m_mutex);
         erased = m_sinks.erase(sink) > 0;
     }
     if (erased) {
@@ -143,7 +143,7 @@ auto Logger<Char, ThreadingPolicy, BufferSize, Allocator>::set_sink_enabled(
 {
     bool found = false;
     {
-        const typename ThreadingPolicy::UniqueLock lock(m_mutex);
+        const typename ThreadingPolicy::template UniqueLock<decltype(m_mutex)> lock(m_mutex);
         if (const auto itr = m_sinks.find(sink); itr != m_sinks.end()) {
             if (itr->second == enabled) {
                 return true;
@@ -162,7 +162,7 @@ template<typename Char, typename ThreadingPolicy, std::size_t BufferSize, typena
 auto Logger<Char, ThreadingPolicy, BufferSize, Allocator>::sink_enabled(
     const std::shared_ptr<SinkType>& sink) const -> bool
 {
-    const typename ThreadingPolicy::SharedLock lock(m_mutex);
+    const typename ThreadingPolicy::template SharedLock<decltype(m_mutex)> lock(m_mutex);
     if (const auto itr = m_sinks.find(sink); itr != m_sinks.end()) {
         return itr->second;
     }
@@ -210,7 +210,7 @@ template<typename Char, typename ThreadingPolicy, std::size_t BufferSize, typena
 template<typename Char, typename ThreadingPolicy, std::size_t BufferSize, typename Allocator>
 auto Logger<Char, ThreadingPolicy, BufferSize, Allocator>::parent() -> std::shared_ptr<Logger>
 {
-    const typename ThreadingPolicy::SharedLock lock(m_mutex);
+    const typename ThreadingPolicy::template SharedLock<decltype(m_mutex)> lock(m_mutex);
     return m_parent;
 }
 
@@ -220,11 +220,11 @@ auto Logger<Char, ThreadingPolicy, BufferSize, Allocator>::set_parent(
 {
     std::shared_ptr<Logger> old_parent;
     {
-        const typename ThreadingPolicy::SharedLock lock(m_mutex);
+        const typename ThreadingPolicy::template SharedLock<decltype(m_mutex)> lock(m_mutex);
         old_parent = m_parent;
     }
     {
-        const typename ThreadingPolicy::UniqueLock lock(m_mutex);
+        const typename ThreadingPolicy::template UniqueLock<decltype(m_mutex)> lock(m_mutex);
         m_parent = parent;
     }
 
@@ -243,7 +243,7 @@ template<typename Char, typename ThreadingPolicy, std::size_t BufferSize, typena
 auto Logger<Char, ThreadingPolicy, BufferSize, Allocator>::add_child(
     const std::shared_ptr<Logger>& child) -> void
 {
-    const typename ThreadingPolicy::UniqueLock lock(m_mutex);
+    const typename ThreadingPolicy::template UniqueLock<decltype(m_mutex)> lock(m_mutex);
     m_children.push_back(child);
 }
 
@@ -251,7 +251,7 @@ template<typename Char, typename ThreadingPolicy, std::size_t BufferSize, typena
 auto Logger<Char, ThreadingPolicy, BufferSize, Allocator>::remove_child(
     const std::shared_ptr<Logger>& child) -> void
 {
-    const typename ThreadingPolicy::UniqueLock lock(m_mutex);
+    const typename ThreadingPolicy::template UniqueLock<decltype(m_mutex)> lock(m_mutex);
     m_children.erase(
         std::remove_if(
             m_children.begin(),
@@ -277,21 +277,22 @@ auto Logger<Char, ThreadingPolicy, BufferSize, Allocator>::update_propagated_sin
     // Snapshot parent
     std::shared_ptr<Logger> parent;
     {
-        const typename ThreadingPolicy::SharedLock lock(m_mutex);
+        const typename ThreadingPolicy::template SharedLock<decltype(m_mutex)> lock(m_mutex);
         parent = m_parent;
     }
 
     // Snapshot propagated sinks
     std::vector<SinkType*> propagated_sinks;
     if (parent && m_propagate) {
-        const typename ThreadingPolicy::SharedLock lock(parent->m_mutex);
+        const typename ThreadingPolicy::template SharedLock<decltype(m_mutex)> lock(
+            parent->m_mutex);
         propagated_sinks = parent->m_propagated_sinks;
     }
 
     // Update the current node's propagated sinks, snapshot children
     std::vector<std::shared_ptr<Logger>> children;
     {
-        const typename ThreadingPolicy::UniqueLock lock(m_mutex);
+        const typename ThreadingPolicy::template UniqueLock<decltype(m_mutex)> lock(m_mutex);
         m_propagated_sinks = propagated_sinks;
         for (const auto& [sink, enabled] : m_sinks) {
             const auto it

--- a/include/slimlog/logger.h
+++ b/include/slimlog/logger.h
@@ -13,8 +13,6 @@
 #include "slimlog/util/string.h"
 #include "slimlog/util/types.h"
 
-#include <slimlog_export.h>
-
 #include <array>
 #include <concepts>
 #include <cstddef>

--- a/include/slimlog/logger.h
+++ b/include/slimlog/logger.h
@@ -365,7 +365,7 @@ public:
             return;
         }
 
-        const typename ThreadingPolicy::SharedLock lock(m_mutex);
+        const typename ThreadingPolicy::template SharedLock<decltype(m_mutex)> lock(m_mutex);
         // Early exit if there are no sinks to propagate to
         if (m_propagated_sinks.empty()) [[unlikely]] {
             return;
@@ -651,7 +651,7 @@ private:
     std::vector<std::weak_ptr<Logger>> m_children;
     std::vector<SinkType*> m_propagated_sinks;
     std::shared_ptr<Logger> m_parent;
-    mutable ThreadingPolicy::SharedMutex m_mutex;
+    mutable typename ThreadingPolicy::SharedMutex m_mutex;
     AtomicWrapper<Level, ThreadingPolicy> m_level;
     AtomicWrapper<bool, ThreadingPolicy> m_propagate;
     static constexpr std::array<Char, 7> DefaultCategory{'d', 'e', 'f', 'a', 'u', 'l', 't'};

--- a/include/slimlog/pattern-inl.h
+++ b/include/slimlog/pattern-inl.h
@@ -92,11 +92,11 @@ auto Pattern<Char>::format(BufferType& out, const Record<Char>& record) -> void
                     formatter.format(out, time_point.first);
                 },
                 [&out, &time_point](const MsecFormatter& formatter) {
-                    constexpr std::size_t MsecInNsec = 1000000;
+                    constexpr std::size_t MsecInNsec = 1'000'000;
                     formatter.format(out, time_point.second / MsecInNsec);
                 },
                 [&out, &time_point](const UsecFormatter& formatter) {
-                    constexpr std::size_t UsecInNsec = 1000;
+                    constexpr std::size_t UsecInNsec = 1'000;
                     formatter.format(out, time_point.second / UsecInNsec);
                 },
                 [&out, &time_point](const NsecFormatter& formatter) {

--- a/include/slimlog/pattern.h
+++ b/include/slimlog/pattern.h
@@ -11,8 +11,6 @@
 #include "slimlog/util/os.h"
 #include "slimlog/util/string.h"
 
-#include <slimlog_export.h>
-
 #include <array>
 #include <chrono>
 #include <cstddef>

--- a/include/slimlog/sink-inl.h
+++ b/include/slimlog/sink-inl.h
@@ -16,7 +16,7 @@ template<typename Char, typename ThreadingPolicy, std::size_t BufferSize, typena
 auto FormattableSink<Char, ThreadingPolicy, BufferSize, Allocator>::set_time_func(
     TimeFunctionType time_func) -> void
 {
-    const typename ThreadingPolicy::UniqueLock lock(m_mutex);
+    const typename ThreadingPolicy::template UniqueLock<decltype(m_mutex)> lock(m_mutex);
     m_pattern.set_time_func(time_func);
 }
 
@@ -24,7 +24,7 @@ template<typename Char, typename ThreadingPolicy, std::size_t BufferSize, typena
 auto FormattableSink<Char, ThreadingPolicy, BufferSize, Allocator>::set_pattern(
     StringViewType pattern) -> void
 {
-    const typename ThreadingPolicy::UniqueLock lock(m_mutex);
+    const typename ThreadingPolicy::template UniqueLock<decltype(m_mutex)> lock(m_mutex);
     m_pattern.set_pattern(pattern);
 }
 
@@ -32,7 +32,7 @@ template<typename Char, typename ThreadingPolicy, std::size_t BufferSize, typena
 auto FormattableSink<Char, ThreadingPolicy, BufferSize, Allocator>::format(
     FormatBufferType& result, const RecordType& record) -> void
 {
-    const typename ThreadingPolicy::SharedLock lock(m_mutex);
+    const typename ThreadingPolicy::template SharedLock<decltype(m_mutex)> lock(m_mutex);
     m_pattern.template format<ThreadingPolicy>(result, record);
 }
 

--- a/include/slimlog/sink.h
+++ b/include/slimlog/sink.h
@@ -10,8 +10,6 @@
 #include "slimlog/pattern.h"
 #include "slimlog/threading.h"
 
-#include <slimlog_export.h>
-
 #include <concepts>
 #include <cstddef>
 #include <memory>

--- a/include/slimlog/sink.h
+++ b/include/slimlog/sink.h
@@ -93,7 +93,7 @@ public:
     /** @brief Buffer type used for log message formatting. */
     using FormatBufferType = FormatBuffer<Char, BufferSize, Allocator>;
     /** @brief Time function type for getting the current time. */
-    using TimeFunctionType = Pattern<Char>::TimeFunctionType;
+    using TimeFunctionType = typename Pattern<Char>::TimeFunctionType;
 
     /**
      * @brief Constructs a new Sink object.
@@ -165,7 +165,7 @@ public:
     template<typename... Pairs>
     auto set_levels(Pairs&&... pairs) -> void
     {
-        const typename ThreadingPolicy::UniqueLock lock(m_mutex);
+        const typename ThreadingPolicy::template UniqueLock<decltype(m_mutex)> lock(m_mutex);
         m_pattern.set_levels(std::forward<Pairs>(pairs)...);
     }
 
@@ -180,7 +180,7 @@ protected:
 
 private:
     Pattern<Char> m_pattern;
-    mutable ThreadingPolicy::SharedMutex m_mutex;
+    mutable typename ThreadingPolicy::SharedMutex m_mutex;
 };
 
 /**

--- a/include/slimlog/sinks/callback_sink-inl.h
+++ b/include/slimlog/sinks/callback_sink-inl.h
@@ -16,7 +16,7 @@ template<typename Char, typename ThreadingPolicy>
 auto CallbackSink<Char, ThreadingPolicy>::message(const RecordType& record) -> void
 {
     if (m_callback) {
-        const typename ThreadingPolicy::UniqueLock lock(m_mutex);
+        const typename ThreadingPolicy::template UniqueLock<decltype(m_mutex)> lock(m_mutex);
         // We can safely convert record.filename and record.function to const char*
         // because they're guaranteed to contain null-terminated strings initially.
         m_callback(

--- a/include/slimlog/sinks/callback_sink.h
+++ b/include/slimlog/sinks/callback_sink.h
@@ -75,7 +75,7 @@ public:
 
 private:
     LogCallback m_callback;
-    mutable ThreadingPolicy::Mutex m_mutex;
+    mutable typename ThreadingPolicy::Mutex m_mutex;
 };
 
 } // namespace slimlog

--- a/include/slimlog/sinks/callback_sink.h
+++ b/include/slimlog/sinks/callback_sink.h
@@ -9,8 +9,6 @@
 #include "slimlog/location.h"
 #include "slimlog/sink.h"
 
-#include <slimlog_export.h>
-
 #include <functional>
 #include <utility>
 

--- a/include/slimlog/sinks/file_sink.h
+++ b/include/slimlog/sinks/file_sink.h
@@ -8,8 +8,6 @@
 #include "slimlog/common.h"
 #include "slimlog/sink.h"
 
-#include <slimlog_export.h>
-
 #include <cstdio>
 #include <memory>
 #include <string_view>

--- a/include/slimlog/sinks/ostream_sink-inl.h
+++ b/include/slimlog/sinks/ostream_sink-inl.h
@@ -20,14 +20,14 @@ auto OStreamSink<Char, ThreadingPolicy, BufferSize, Allocator>::message(const Re
     this->format(buffer, record);
     buffer.push_back('\n');
 
-    const typename ThreadingPolicy::UniqueLock lock(m_mutex);
+    const typename ThreadingPolicy::template UniqueLock<decltype(m_mutex)> lock(m_mutex);
     m_ostream.write(buffer.begin(), buffer.size());
 }
 
 template<typename Char, typename ThreadingPolicy, std::size_t BufferSize, typename Allocator>
 auto OStreamSink<Char, ThreadingPolicy, BufferSize, Allocator>::flush() -> void
 {
-    const typename ThreadingPolicy::UniqueLock lock(m_mutex);
+    const typename ThreadingPolicy::template UniqueLock<decltype(m_mutex)> lock(m_mutex);
     m_ostream.flush();
 }
 

--- a/include/slimlog/sinks/ostream_sink.h
+++ b/include/slimlog/sinks/ostream_sink.h
@@ -8,8 +8,6 @@
 #include "slimlog/common.h"
 #include "slimlog/sink.h"
 
-#include <slimlog_export.h>
-
 #include <cstddef>
 #include <memory>
 #include <ostream>

--- a/include/slimlog/sinks/ostream_sink.h
+++ b/include/slimlog/sinks/ostream_sink.h
@@ -86,7 +86,7 @@ public:
 
 private:
     std::basic_ostream<Char>& m_ostream;
-    mutable ThreadingPolicy::Mutex m_mutex;
+    mutable typename ThreadingPolicy::Mutex m_mutex;
 };
 
 } // namespace slimlog

--- a/include/slimlog/util/os.h
+++ b/include/slimlog/util/os.h
@@ -45,6 +45,10 @@
 #elif defined(__APPLE__)
 #include <AvailabilityMacros.h> // for MAC_OS_X_VERSION_MAX_ALLOWED
 #include <pthread.h> // for pthread_threadid_np
+#elif defined(__QNXNTO__)
+#include <pthread.h> // for pthread_self
+#else
+#include <thread> // for std::this_thread::get_id
 #endif
 #endif
 
@@ -109,6 +113,8 @@ namespace slimlog::util::os {
         ::pthread_threadid_np(nullptr, &tid);
 #endif
         cached_tid = static_cast<std::size_t>(tid);
+#elif defined(__QNXNTO__)
+        cached_tid = static_cast<std::size_t>(::pthread_self());
 #else // Default to standard C++11 (other Unix)
         cached_tid
             = static_cast<std::size_t>(std::hash<std::thread::id>()(std::this_thread::get_id()));
@@ -211,10 +217,10 @@ inline void atomic_store_relaxed(T* ptr, T value) noexcept
 #if SLIMLOG_HAS_CLOCK_GETTIME
 #ifdef CLOCK_REALTIME_COARSE
     // On Linux we can use CLOCK_REALTIME_COARSE for better performance
-    std::ignore = clock_gettime(CLOCK_REALTIME_COARSE, &curtime);
+    std::ignore = ::clock_gettime(CLOCK_REALTIME_COARSE, &curtime);
 #else
     // Elsewhere use standard CLOCK_REALTIME which is guaranteed to be available
-    std::ignore = clock_gettime(CLOCK_REALTIME, &curtime);
+    std::ignore = ::clock_gettime(CLOCK_REALTIME, &curtime);
 #endif
 #else
     std::ignore = ::timespec_get(&curtime, TIME_UTC);

--- a/include/slimlog/util/types.h
+++ b/include/slimlog/util/types.h
@@ -35,6 +35,10 @@ struct Overloaded : Ts... {
     using Ts::operator()...;
 };
 
+/** @brief Deduction guide for Overloaded. */
+template<class... Ts>
+Overloaded(Ts...) -> Overloaded<Ts...>;
+
 /**
  * @brief Defines a type that is always false for unconditional static assertions.
  *

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,6 +107,25 @@ target_include_directories(
 )
 
 # ---------------------------------------------------------------------------------------
+# Check for platform-specific symbols
+# ---------------------------------------------------------------------------------------
+include(CheckCXXSymbolExists)
+set(symbol_checks "clock_gettime|ctime|CLOCK_GETTIME" "timespec_get|ctime|TIMESPEC_GET"
+                  "fwrite_unlocked|cstdio|FWRITE_UNLOCKED"
+)
+foreach(check IN LISTS symbol_checks)
+    string(REPLACE "|" ";" check_items "${check}")
+    list(GET check_items 0 symbol)
+    list(GET check_items 1 header)
+    list(GET check_items 2 suffix)
+    check_cxx_symbol_exists("${symbol}" "${header}" SLIMLOG_HAS_${suffix})
+    if(SLIMLOG_HAS_${suffix})
+        target_compile_definitions(slimlog PUBLIC SLIMLOG_HAS_${suffix})
+        target_compile_definitions(slimlog-header-only INTERFACE SLIMLOG_HAS_${suffix})
+    endif()
+endforeach()
+
+# ---------------------------------------------------------------------------------------
 # Use fmt package if required
 # ---------------------------------------------------------------------------------------
 if(SLIMLOG_FMTLIB OR SLIMLOG_FMTLIB_HO)
@@ -125,7 +144,6 @@ if(SLIMLOG_FMTLIB OR SLIMLOG_FMTLIB_HO)
     endif()
 
     # Check which unicode types are supported
-    include(CheckCXXSymbolExists)
     if(${fmt_VERSION} VERSION_GREATER_EQUAL 11.0.0)
         set(fmt_format_context "fmt::buffered_context")
     else()
@@ -138,18 +156,6 @@ if(SLIMLOG_FMTLIB OR SLIMLOG_FMTLIB_HO)
     get_target_property(FMT_INCLUDE_DIRS fmt::fmt INTERFACE_INCLUDE_DIRECTORIES)
     set(CMAKE_REQUIRED_INCLUDES ${FMT_INCLUDE_DIRS})
     set(CMAKE_REQUIRED_DEFINITIONS -DFMT_HEADER_ONLY)
-
-    check_cxx_symbol_exists("clock_gettime" "ctime" SLIMLOG_HAS_CLOCK_GETTIME)
-    if(SLIMLOG_HAS_CLOCK_GETTIME)
-        target_compile_definitions(slimlog PUBLIC SLIMLOG_HAS_CLOCK_GETTIME)
-        target_compile_definitions(slimlog-header-only INTERFACE SLIMLOG_HAS_CLOCK_GETTIME)
-    endif()
-
-    check_cxx_symbol_exists("fwrite_unlocked" "cstdio" SLIMLOG_HAS_FWRITE_UNLOCKED)
-    if(SLIMLOG_HAS_FWRITE_UNLOCKED)
-        target_compile_definitions(slimlog PUBLIC SLIMLOG_HAS_FWRITE_UNLOCKED)
-        target_compile_definitions(slimlog-header-only INTERFACE SLIMLOG_HAS_FWRITE_UNLOCKED)
-    endif()
 
     foreach(size 8 16 32)
         check_cxx_symbol_exists(
@@ -176,7 +182,6 @@ if(SLIMLOG_FMTLIB OR SLIMLOG_FMTLIB_HO)
     set(PKG_CONFIG_REQUIRES fmt)
 else()
     # If fmtlib is not available, check for C++20 std::format()
-    include(CheckCXXSymbolExists)
     check_cxx_symbol_exists(
         "std::make_format_args<std::format_context, std::chrono::sys_seconds>" "format;chrono"
         HAS_CXX20_FORMAT

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,17 +60,7 @@ target_include_directories(
 
 # Generate a header with export macros
 include(GenerateExportHeader)
-set(export_custom_content
-    [[
-#ifdef SLIMLOG_HEADER_ONLY
-#  undef SLIMLOG_EXPORT
-#  define SLIMLOG_EXPORT
-#  undef SLIMLOG_NO_EXPORT
-#  define SLIMLOG_NO_EXPORT
-#endif
-]]
-)
-generate_export_header(slimlog CUSTOM_CONTENT_FROM_VARIABLE export_custom_content)
+generate_export_header(slimlog)
 
 if(SLIMLOG_SANITIZERS AND COMMAND target_enable_sanitizers)
     target_enable_sanitizers(

--- a/src/slimlog.cpp
+++ b/src/slimlog.cpp
@@ -6,8 +6,6 @@
 #include "slimlog/sinks/null_sink.h"
 #include "slimlog/sinks/ostream_sink.h"
 
-#include <slimlog_export.h>
-
 #ifndef SLIMLOG_HEADER_ONLY
 // IWYU pragma: begin_keep
 #include "slimlog/format-inl.h"


### PR DESCRIPTION
It simplifies CMakeLists and make it easier to use the library as header-only.