### PR TITLE
CMake: make compatible with at least v3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.23...3.26)
+cmake_minimum_required(VERSION 3.14)
 
 if(SLIMLOG_TESTS)
     list(APPEND VCPKG_MANIFEST_FEATURES "testing")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,26 +17,7 @@ add_library(slimlog::slimlog ALIAS slimlog)
 file(GLOB PUBLIC_HEADERS ${PROJECT_SOURCE_DIR}/include/slimlog/*.h
      ${PROJECT_SOURCE_DIR}/include/slimlog/sinks/*.h ${PROJECT_SOURCE_DIR}/include/slimlog/util/*.h
 )
-
-target_sources(
-    slimlog
-    PUBLIC FILE_SET
-           public_headers
-           TYPE
-           HEADERS
-           BASE_DIRS
-           ${PROJECT_SOURCE_DIR}/include
-           FILES
-           ${PUBLIC_HEADERS}
-           FILE_SET
-           generated_headers
-           TYPE
-           HEADERS
-           BASE_DIRS
-           ${CMAKE_CURRENT_BINARY_DIR}
-           FILES
-           ${CMAKE_CURRENT_BINARY_DIR}/slimlog_export.h
-)
+target_sources(slimlog PRIVATE $<BUILD_INTERFACE:${PUBLIC_HEADERS}>)
 
 # Compiler / language configuration.
 set_target_properties(
@@ -197,11 +178,17 @@ endif()
 install(
     TARGETS slimlog slimlog-header-only
     EXPORT slimlog-targets
-    FILE_SET public_headers FILE_SET generated_headers
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
+
+# Install header files manually for CMake <3.23 compatibility
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+# Install generated header
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/slimlog_export.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
 # ---------------------------------------------------------------------------------------
 # Install CMake config files
 # ---------------------------------------------------------------------------------------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,22 +1,20 @@
 include(FetchContent)
 set(FETCHCONTENT_BASE_DIR ${PROJECT_BINARY_DIR}/deps)
 
-fetchcontent_declare(
-    mettle
-    GIT_REPOSITORY https://github.com/polter-rnd/mettle.git
-    EXCLUDE_FROM_ALL # don't build by default
-    FIND_PACKAGE_ARGS # try find_package() first
-)
-fetchcontent_makeavailable(mettle)
+find_package(mettle CONFIG QUIET)
+if(NOT mettle_FOUND)
+    fetchcontent_declare(mettle GIT_REPOSITORY https://github.com/polter-rnd/mettle.git)
+    fetchcontent_makeavailable(mettle)
+endif()
 
 set(FMT_SYSTEM_HEADERS TRUE)
-fetchcontent_declare(
-    fmt
-    GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-    EXCLUDE_FROM_ALL # don't build by default
-    FIND_PACKAGE_ARGS # try find_package() first
-)
-fetchcontent_makeavailable(fmt)
+
+find_package(fmt CONFIG QUIET)
+if(NOT fmt_FOUND)
+    # If system fmt not found, fetch it
+    fetchcontent_declare(fmt GIT_REPOSITORY https://github.com/fmtlib/fmt.git)
+    fetchcontent_makeavailable(fmt)
+endif()
 
 if(SLIMLOG_SANITIZERS
    AND COMMAND target_enable_sanitizers


### PR DESCRIPTION
Since we support GCC11 and Clang14 which are provided in Ubuntu 22.04, would be nice to also support CMake from that times.